### PR TITLE
Fix #3: Add ALC Resolving fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.4] - 05-03-2025
+
+- Add ALC Resolving fallback to fix FileLoadException for BepInEx-loaded assemblies (fixes #3)
+
 ## [1.0.3] - 26-12-2025
 
 - Fix to load the right MonkeyLoaderWrapper DLL on Linux

--- a/MonkeyLoaderLoader/Loader.cs
+++ b/MonkeyLoaderLoader/Loader.cs
@@ -96,6 +96,13 @@ class MonkeyLoaderLoader
 			Plugin.Log!.LogDebug($"Preloading: {name}");
 			Assembly.LoadFrom(file);
 		}
+
+		foreach (var alc in AssemblyLoadContext.All)
+		{
+			alc.Resolving += (context, assemblyName) =>
+				AppDomain.CurrentDomain.GetAssemblies()
+					.FirstOrDefault(a => a.GetName().Name == assemblyName.Name);
+		}
 	}
 
 	public static void Load(Harmony harmony)

--- a/MonkeyLoaderLoader/MonkeyLoaderLoader.csproj
+++ b/MonkeyLoaderLoader/MonkeyLoaderLoader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>1.0.4</Version>
     <Authors>Nytra</Authors>
     <TargetFramework>net10.0</TargetFramework>
     <RepositoryUrl>https://github.com/Nytra/MonkeyLoaderLoader-BepInEx</RepositoryUrl>

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -6,7 +6,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "Nytra" # TODO: Change this to the team you're uploading the mod to on Thunderstore
 name = "MonkeyLoaderLoader" # Change this to your mod's name, no spaces or special characters, max 128 characters
-versionNumber = "1.0.3" # Change this to your mod's version, must be in semantic versioning format (e.g. 1.0.0, 2.1.3, 0.1.0-alpha.1), Only read during manual usage of tcli.
+versionNumber = "1.0.4" # Change this to your mod's version, must be in semantic versioning format (e.g. 1.0.0, 2.1.3, 0.1.0-alpha.1), Only read during manual usage of tcli.
 description = "Loads MonkeyLoader with BepInEx. You must have already installed the MonkeyLoader Resonite GamePack for this to work properly." # TODO: Change this to your mod's description, max 250 characters
 websiteUrl = "https://github.com/Nytra/MonkeyLoaderLoader-BepInEx" # TODO: Change this to your mod's website/repository, or leave blank
 containsNsfwContent = false


### PR DESCRIPTION
#3
In PreloadAssemblies(), after preloading MonkeyLoader DLLs, attach a Resolving event handler to all existing ALCs that falls back to AppDomain.CurrentDomain.GetAssemblies() when an assembly cannot be found within the ALC itself: